### PR TITLE
Fixes for newer Data.Bits

### DIFF
--- a/src/Data/Vector/Bit.hs
+++ b/src/Data/Vector/Bit.hs
@@ -28,7 +28,7 @@ module Data.Vector.Bit (
   unpackInteger, packInteger, unpackInt, packInt,
 
   -- * Utilities
-  pad, padMax, zipPad, trimLeading
+  pad, padMax, zipPad, zipPadWith, trimLeading
   )
 
 where


### PR DESCRIPTION
The latest version of Data.Bits has changed the interface somewhat, and bit-vector was no longer compatible.

Most notably, `Num` is no longer a superclass of `Bits`, which caused a type error in pack.

The interface also has some new methods (`bit`,`testBit`, `popCount`), and in order to support these effectively, I also modified `(.|.)` and `xor` to pad before zipping. (Since otherwise, there is no useful definition of bit).
