### PR TITLE
Loosen version restriction on vector

### DIFF
--- a/bit-vector.cabal
+++ b/bit-vector.cabal
@@ -17,7 +17,7 @@ Library
   Exposed-modules:   Data.Vector.Bit
   Hs-source-dirs:    src
   Build-depends:     base == 4.*,
-                     vector == 0.9.*
+                     vector >= 0.9
   ghc-options:       -Wall
                      -- orphans are kind of the point
                      -fno-warn-orphans
@@ -27,7 +27,7 @@ Test-Suite Tests
   hs-source-dirs:    test
   Main-is:	     Data/Vector/Bit/Tests.hs
   Build-depends:     base == 4.*,
-                     vector == 0.9.*,
+                     vector >= 0.9,
                      QuickCheck == 2.4.*,
                      test-framework >= 0.4.1.1,
                      test-framework-quickcheck2 == 0.2.*,


### PR DESCRIPTION
Cannot build bit-vector with newer vector with the version spec'd to "==0.9.*"
This fix simply looses the spec to be ">=0.9"
